### PR TITLE
remove wire lib (to stop i2c bus initialisation)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-AC-Room8266-ESP8266-LIB
-version=1.1.0
+version=1.2.0
 author=Austin Creations
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP8266 Room8266 library for Open eXtensible Rack System firmware

--- a/src/OXRS_Room8266.cpp
+++ b/src/OXRS_Room8266.cpp
@@ -5,7 +5,6 @@
 #include "Arduino.h"
 #include "OXRS_Room8266.h"
 
-#include <Wire.h>                     // For I2C
 #include <ESP8266WiFi.h>              // For networking
 #include <Ethernet.h>                 // For networking
 #include <Adafruit_NeoPixel.h>        // For RGBW LED


### PR DESCRIPTION
Not need by this library so shouldn't be there (in case parent firmware isn't using I2C)